### PR TITLE
feat(celery): remove hardcoded CELERY_BROKER_URL from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     depends_on:
       - django_app
       - redis
-    environment:
-      - CELERY_BROKER_URL=redis://redis:6379/0
   redis:
     image: redis:7-alpine
     ports:


### PR DESCRIPTION
agora vai